### PR TITLE
fix: parsing GitHub urls

### DIFF
--- a/indexer/src/utils/parsing.ts
+++ b/indexer/src/utils/parsing.ts
@@ -1,6 +1,6 @@
 export interface ParseGitHubUrlResult {
   owner: string;
-  name: string;
+  name?: string;
 }
 
 /**
@@ -14,14 +14,21 @@ export function parseGithubUrl(url: any): ParseGitHubUrlResult | null {
   }
 
   // eslint-disable-next-line no-useless-escape
-  const regex = /\/\/github.com\/([^/]+)\/([^\./]+)/g;
+  const regex = /\/\/github.com\/([^/]+)(\/([^\./]+))?/g;
   const matches = regex.exec(url);
-  if (!matches || matches.length < 3) {
+  if (!matches || matches.length < 2) {
+    return null;
+  }
+
+  const owner = matches[1];
+  const name = matches[3];
+
+  if (!owner) {
     return null;
   }
 
   return {
-    owner: matches[1],
-    name: matches[2],
+    owner,
+    name,
   };
 }

--- a/indexer/test/utils/parsing.test.ts
+++ b/indexer/test/utils/parsing.test.ts
@@ -25,6 +25,22 @@ describe("parsing", () => {
     expect(result?.name).toEqual("hypercerts");
   });
 
+  it("parses just a github org - no trailing slash", () => {
+    const url = "ssh://github.com/hypercerts-org";
+    const result = parseGithubUrl(url);
+    expect(result).not.toBeNull();
+    expect(result?.owner).toEqual("hypercerts-org");
+    expect(result?.name).toBeUndefined();
+  });
+
+  it("parses just a github org - trailing slash", () => {
+    const url = "ssh://github.com/hypercerts-org/";
+    const result = parseGithubUrl(url);
+    expect(result).not.toBeNull();
+    expect(result?.owner).toEqual("hypercerts-org");
+    expect(result?.name).toBeUndefined();
+  });
+
   it("doesn't parse gitlab ssh urls", () => {
     const url = "ssh://gitlab.com/hypercerts-org/hypercerts.git";
     const result = parseGithubUrl(url);


### PR DESCRIPTION
* Previously the owner and repo name must exist to return
* Now can parse GitHub urls with just the owner/organization without a repo