### PR TITLE
Do not fail on errors. 

### DIFF
--- a/indexer/src/actions/oss-directory.ts
+++ b/indexer/src/actions/oss-directory.ts
@@ -35,7 +35,13 @@ export async function importOssDirectory(
       continue;
     }
     logger.info(`projects[${i}]: Upserting ${p.slug}`);
-    await ossUpsertProject(p);
+    try {
+      await ossUpsertProject(p);
+    } catch (e) {
+      logger.error(
+        `projects[${i}]: error occured processing project ${p.slug}. Skipping with error: ${e}`,
+      );
+    }
   }
 
   logger.info("Upserting collections...");
@@ -48,7 +54,13 @@ export async function importOssDirectory(
       continue;
     }
     logger.info(`collections[${i}]: Upserting ${c.slug}`);
-    await ossUpsertCollection(c);
+    try {
+      await ossUpsertCollection(c);
+    } catch (e) {
+      logger.error(
+        `collections[${i}]: error occured processing colelction ${c.slug}. Skipping with error: ${e}`,
+      );
+    }
   }
 
   logger.info("Done");


### PR DESCRIPTION
@ryscheng. I noticed this the other day when I ran the import script locally. I am not sure this is the solution but it allowed me to move forward so I could replicate what's on the prod db on my local db.

Ideally we'd have a whole setup to track failures and maybe even backoff on certain event collection if they're continuously failing (so we don't, say, blow API quotas)