### PR TITLE
fix: index jobs should only build indexer

### DIFF
--- a/.github/workflows/indexer-autocrawl.yml
+++ b/.github/workflows/indexer-autocrawl.yml
@@ -35,6 +35,6 @@ jobs:
           cache: "pnpm"
           node-version: "18.x"
       - name: Build
-        run: pnpm build
+        run: pnpm build:indexer
       - name: Run
         run: pnpm start:indexer runAutocrawl

--- a/.github/workflows/indexer-manual.yml
+++ b/.github/workflows/indexer-manual.yml
@@ -47,6 +47,6 @@ jobs:
           cache: "pnpm"
           node-version: "18.x"
       - name: Build
-        run: pnpm build
+        run: pnpm build:indexer
       - name: Run
         run: pnpm start:indexer ${{ inputs.command }} ${{ inputs.args }}

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
   },
   "scripts": {
     "build": "turbo run build --concurrency=100%",
-    "build:frontend": "turbo run build --filter=@hypercerts-org/frontend",
     "build:docs": "turbo run build --filter=@hypercerts-org/docs",
+    "build:frontend": "turbo run build --filter=@hypercerts-org/frontend",
+    "build:indexer": "turbo run build --filter=@hypercerts-org/indexer",
     "copy": "yarn copy:frontend && yarn copy:docs && yarn copy:html",
     "copy:docs": "mkdir -p ./build/docs/ && cp -r ./docs/build/* ./build/docs/",
     "copy:frontend": "mkdir -p ./build/ && cp -r ./frontend/out/* ./build/ && cp ./frontend/_redirects ./build/",


### PR DESCRIPTION
* Previously we were running the build for frontend on the indexer jobs. This requires environment variables we don't have
* Reduce the scope of the build to just the indexer