### PR TITLE
feat: middleware to proxy `/project/:slug` and

### DIFF
--- a/frontend/app/artifact/[namespace]/[...name]/page.tsx
+++ b/frontend/app/artifact/[namespace]/[...name]/page.tsx
@@ -1,37 +1,15 @@
 import { notFound } from "next/navigation";
-import { ArtifactNamespace } from "@hypercerts-org/indexer";
-import { cachedGetArtifactByName } from "../../../../../lib/db";
-import { logger } from "../../../../../lib/logger";
-import { catchallPathToString } from "../../../../../lib/paths";
+import { cachedGetArtifactByName } from "../../../../lib/db";
+import { logger } from "../../../../lib/logger";
+import {
+  catchallPathToString,
+  pathToNamespaceEnum,
+} from "../../../../lib/paths";
 
 /**
  * TODO: This SSR route allows us to fetch the project from the database
  * on the first HTTP request, which should be faster than fetching it client-side
  */
-
-/**
- * Converts a path string to an ArtifactNamespace enum
- * @param namespacePath
- * @returns
- */
-const pathToNamespaceEnum = (namespacePath: string) => {
-  switch (namespacePath) {
-    case "github":
-      return ArtifactNamespace.GITHUB;
-    case "gitlab":
-      return ArtifactNamespace.GITLAB;
-    case "npm":
-      return ArtifactNamespace.NPM_REGISTRY;
-    case "ethereum":
-      return ArtifactNamespace.ETHEREUM;
-    case "optimism":
-      return ArtifactNamespace.OPTIMISM;
-    case "goerli":
-      return ArtifactNamespace.GOERLI;
-    default:
-      return null;
-  }
-};
 
 type ArtifactPageProps = {
   params: {

--- a/frontend/app/project/[...slug]/page.tsx
+++ b/frontend/app/project/[...slug]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
-import { cachedGetProjectBySlug } from "../../../../lib/db";
-import { logger } from "../../../../lib/logger";
-import { catchallPathToString } from "../../../../lib/paths";
+import { cachedGetProjectBySlug } from "../../../lib/db";
+import { logger } from "../../../lib/logger";
+import { catchallPathToString } from "../../../lib/paths";
 
 /**
  * TODO: This SSR route allows us to fetch the project from the database

--- a/frontend/lib/errors.ts
+++ b/frontend/lib/errors.ts
@@ -6,3 +6,5 @@ export class NotImplementedError extends Error {
     super(msg);
   }
 }
+
+export class HttpError extends Error {}

--- a/frontend/lib/paths.ts
+++ b/frontend/lib/paths.ts
@@ -7,3 +7,27 @@
 export const catchallPathToString = (parts: string[]) => {
   return parts.map((p) => decodeURIComponent(p)).join("/");
 };
+
+/**
+ * Converts a path string to an  enum
+ * @param namespacePath
+ * @returns
+ */
+export const pathToNamespaceEnum = (namespacePath: string) => {
+  switch (namespacePath) {
+    case "github":
+      return "GITHUB";
+    case "gitlab":
+      return "GITLAB";
+    case "npm":
+      return "NPM_REGISTRY";
+    case "ethereum":
+      return "ETHEREUM";
+    case "optimism":
+      return "OPTIMISM";
+    case "goerli":
+      return "GOERLI";
+    default:
+      return null;
+  }
+};

--- a/frontend/lib/supabase-client.ts
+++ b/frontend/lib/supabase-client.ts
@@ -1,18 +1,49 @@
 import { createClient } from "@supabase/supabase-js";
 import { SUPABASE_ANON_KEY, SUPABASE_URL } from "./config";
+import { HttpError } from "./errors";
 
 export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
-export interface SupabaseQueryArgs {
-  table: string;
-  columns?: string[];
-}
+export type SupabaseQueryArgs = {
+  tableName: string; // table to query
+  columns?: string; // comma-delimited column names (e.g. `address,claimId`)
+  filters?: any; // A list of filters, where each filter is `[ column, operator, value ]`
+  // See https://supabase.com/docs/reference/javascript/filter
+  // e.g. [ [ "address", "eq", "0xabc123" ] ]
+  limit?: number; // Number of results to return
+  orderBy?: string; // Name of column to order by
+  orderAscending?: boolean; // True if ascending, false if descending
+};
 
 export async function supabaseQuery(args: SupabaseQueryArgs): Promise<any[]> {
-  const { table, columns } = args;
-  const { data, error } = await supabase.from(table).select(columns?.join(","));
+  const { tableName, columns, filters, limit, orderBy, orderAscending } = args;
+  let query = supabase.from(tableName).select(columns);
+  // Iterate over the filters
+  if (Array.isArray(filters)) {
+    for (let i = 0; i < filters.length; i++) {
+      const f = filters[i];
+      if (!Array.isArray(f) || f.length < 3) {
+        console.warn(`Invalid supabase filter: ${f}`);
+        continue;
+      }
+      query = query.filter(f[0], f[1], f[2]);
+    }
+  }
+  // Limits
+  if (limit) {
+    query = query.limit(limit);
+  }
+  // Ordering
+  if (orderBy) {
+    query = query.order(orderBy, { ascending: orderAscending });
+  }
+  // Execute query
+  const { data, error, status } = await query;
   if (error) {
     throw error;
+  } else if (status > 300) {
+    throw new HttpError(`Invalid status code: ${status}`);
   }
+
   return data;
 }

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+import { supabaseQuery } from "./lib/supabase-client";
+import { catchallPathToString, pathToNamespaceEnum } from "./lib/paths";
+
+/**
+ * Rewrites for `/project/:slug`
+ * @param request
+ * @param slug
+ * @returns
+ */
+async function projectMiddleware(request: NextRequest, slug: string) {
+  // Get project metadata from the database
+  const projects = await supabaseQuery({
+    tableName: "Project",
+    columns: "id,slug",
+    filters: [["slug", "eq", slug]],
+  });
+  if (!projects || projects.length < 1) {
+    console.warn(`Cannot find project (slug=${slug})`);
+    return NextResponse.next();
+  }
+
+  // Get the project
+  const project = projects[0];
+  //console.log(project);
+  return NextResponse.rewrite(
+    new URL(`/projectById/${project.id}`, request.url),
+  );
+}
+
+/**
+ * Rewrites for `/artifact/:namespace/:name`
+ * @param request
+ * @param namespace
+ * @param name
+ * @returns
+ */
+async function artifactMiddleware(
+  request: NextRequest,
+  namespace: string,
+  name: string,
+) {
+  // Get artifact metadata from the database
+  const artifacts = await supabaseQuery({
+    tableName: "Artifact",
+    columns: "id,namespace,name",
+    filters: [
+      ["namespace", "eq", namespace],
+      ["name", "eq", name],
+    ],
+  });
+  if (!artifacts || artifacts.length < 1) {
+    console.warn(`Cannot find artifact (namespace=${namespace}, name=${name})`);
+    return NextResponse.next();
+  }
+
+  // Get the project
+  const artifact = artifacts[0];
+  //console.log(artifact);
+  return NextResponse.rewrite(
+    new URL(`/artifactById/${artifact.id}`, request.url),
+  );
+}
+
+/**
+ * Route depending on whether the path starts with `/project` or `/artifact`
+ * @param request
+ * @returns
+ */
+export async function middleware(request: NextRequest) {
+  const pathParts = request.nextUrl.pathname.split("/").filter((x) => !!x);
+  if (pathParts.length > 1 && pathParts[0] === "project") {
+    return projectMiddleware(request, catchallPathToString(pathParts.slice(1)));
+  } else if (pathParts.length > 2 && pathParts[0] === "artifact") {
+    const namespaceEnum = pathToNamespaceEnum(pathParts[1]);
+    if (namespaceEnum) {
+      return artifactMiddleware(
+        request,
+        namespaceEnum,
+        catchallPathToString(pathParts.slice(2)),
+      );
+    }
+  }
+  console.warn("Invalid path: ", pathParts);
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/artifact/:path+", "/project/:path+"],
+};

--- a/frontend/plasmic-init-client.tsx
+++ b/frontend/plasmic-init-client.tsx
@@ -54,31 +54,8 @@ PLASMIC.registerComponent(SupabaseQuery, {
       type: "string",
       helpText: "Name to use in Plasmic data picker. Must be unique per query.",
     },
-    children: "slot",
-    loadingChildren: {
-      type: "slot",
-      defaultValue: {
-        type: "text",
-        value: "Placeholder",
-      },
-    },
-    ignoreLoading: {
-      type: "boolean",
-      helpText: "Don't show 'loadingChildren' even if we're still loading data",
-      advanced: true,
-    },
-    errorChildren: {
-      type: "slot",
-      defaultValue: {
-        type: "text",
-        value: "Placeholder",
-      },
-    },
-    ignoreError: {
-      type: "boolean",
-      helpText: "Don't show 'errorChildren' even if we get an error",
-      advanced: true,
-    },
+
+    // SupabaseQueryArgs
     tableName: {
       type: "string",
       helpText: "Supabase table name",
@@ -103,6 +80,33 @@ PLASMIC.registerComponent(SupabaseQuery, {
     orderAscending: {
       type: "boolean",
       helpText: "True if ascending, false if descending",
+    },
+
+    // Plasmic elements
+    children: "slot",
+    loadingChildren: {
+      type: "slot",
+      defaultValue: {
+        type: "text",
+        value: "Placeholder",
+      },
+    },
+    ignoreLoading: {
+      type: "boolean",
+      helpText: "Don't show 'loadingChildren' even if we're still loading data",
+      advanced: true,
+    },
+    errorChildren: {
+      type: "slot",
+      defaultValue: {
+        type: "text",
+        value: "Placeholder",
+      },
+    },
+    ignoreError: {
+      type: "boolean",
+      helpText: "Don't show 'errorChildren' even if we get an error",
+      advanced: true,
     },
     useTestData: {
       type: "boolean",


### PR DESCRIPTION
`/artifact/:namespace/:name`

* Added global middleware to handle these routes. Just proxies to `/artifactById/` and `/projectById` respectively
* Abstract out the ArtifactNamespace enum matching to a generic function
* Abstract out SupabaseQuery to a generic function