### PR TITLE
Load commits (with a generic event recorder)

### DIFF
--- a/indexer/package.json
+++ b/indexer/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "@cowprotocol/ts-dune-client": "^0.0.2",
+    "@octokit/types": "^11.1.0",
     "@prisma/client": "^5.1.1",
     "chalk": "^5.3.0",
     "dayjs": "^1.11.9",
@@ -63,6 +64,7 @@
     "lodash": "^4.17.21",
     "luxon": "^3.4.0",
     "npm-registry-fetch": "^15.0.0",
+    "octokit": "^3.1.0",
     "ora": "^7.0.1",
     "oss-directory": "^0.0.4",
     "ts-adt": "^2.1.2",

--- a/indexer/prisma/migrations/20230828184711_add_contributor_namespace_git_email/migration.sql
+++ b/indexer/prisma/migrations/20230828184711_add_contributor_namespace_git_email/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "ContributorNamespace" ADD VALUE 'GIT_EMAIL';

--- a/indexer/prisma/migrations/20230828191601_add_contributor_namespace_git_name/migration.sql
+++ b/indexer/prisma/migrations/20230828191601_add_contributor_namespace_git_name/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "ContributorNamespace" ADD VALUE 'GIT_NAME';

--- a/indexer/prisma/schema.prisma
+++ b/indexer/prisma/schema.prisma
@@ -213,5 +213,10 @@ enum ArtifactNamespace {
 
 enum ContributorNamespace {
   GITHUB_USER
+  // If a commit doesn't have a github user use `GIT_EMAIL`
+  GIT_EMAIL
+  // If a commit doesn't have a git email use `GIT_NAME`
+  GIT_NAME
+
   EOA_ADDRESS
 }

--- a/indexer/src/actions/github/fetch/commits.ts
+++ b/indexer/src/actions/github/fetch/commits.ts
@@ -1,0 +1,250 @@
+import { DateTime } from "luxon";
+import {
+  BasicEventTypeStrategy,
+  IEventRecorder,
+  IncompleteArtifact,
+  IncompleteContributor,
+  IncompleteEvent,
+} from "../../../recorder/types.js";
+import {
+  ArtifactNamespace,
+  ArtifactType,
+  ContributorNamespace,
+  EventType,
+  Prisma,
+  PrismaClient,
+} from "@prisma/client";
+import { BatchEventRecorder } from "../../../recorder/recorder.js";
+import { prisma as prismaClient } from "../../../db/prisma-client.js";
+import { logger } from "../../../utils/logger.js";
+import { CommonArgs } from "../../../utils/api.js";
+import { GITHUB_TOKEN } from "../../../config.js";
+import { Octokit } from "octokit";
+import { GetResponseDataTypeFromEndpointMethod } from "@octokit/types";
+
+type Commit = GetResponseDataTypeFromEndpointMethod<
+  Octokit["rest"]["repos"]["getCommit"]
+>;
+type GithubRepoLocator = { owner: string; repo: string };
+
+export class GithubCommitFetcher {
+  private recorder: IEventRecorder;
+  private gh: Octokit;
+  private prisma: PrismaClient;
+
+  constructor(prisma: PrismaClient, gh: Octokit, recorder: IEventRecorder) {
+    this.prisma = prisma;
+    this.recorder = recorder;
+    this.gh = gh;
+  }
+
+  async run() {
+    this.recorder.registerEventType(
+      EventType.COMMIT_CODE,
+      new BasicEventTypeStrategy(
+        {
+          eventType: EventType.COMMIT_CODE,
+        },
+        async (directory, event) => {
+          const details = event.details as { sha: string };
+          const artifact = await directory.artifactFromId(event.artifactId);
+          return `${artifact.name}::${artifact.namespace}::${details.sha}`;
+        },
+        async (_directory, event) => {
+          const details = event.details as { sha: string };
+          const artifact = event.artifact;
+          return `${artifact.name}::${artifact.namespace}::${details.sha}`;
+        },
+      ),
+    );
+
+    this.recorder.setActorScope(
+      [ArtifactNamespace.GITHUB],
+      [
+        ContributorNamespace.GITHUB_USER,
+        ContributorNamespace.GIT_EMAIL,
+        ContributorNamespace.GIT_NAME,
+      ],
+    );
+
+    const repos = await this.loadRelevantRepos();
+
+    for (const repo of repos) {
+      this.recordEventsForRepo(repo);
+    }
+
+    // Report that we've completed the job
+    await this.recorder.waitAll();
+  }
+
+  private async loadRelevantRepos(): Promise<GithubRepoLocator[]> {
+    const projects = await this.prisma.project.findMany({
+      where: {
+        name: {
+          in: ["0xSplits", "gnosis-safe", "Uniswap"],
+        },
+      },
+      include: {
+        artifacts: {
+          include: {
+            artifact: true,
+          },
+          where: {
+            artifact: {
+              namespace: {
+                in: [ArtifactNamespace.GITHUB],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return projects.flatMap((p) => {
+      return p.artifacts
+        .map((a) => {
+          const rawURL = a.artifact.url;
+          const repo = { owner: "", repo: "" };
+          if (!rawURL) {
+            return repo;
+          }
+          const repoURL = new URL(rawURL);
+          if (repoURL.host !== "github.com") {
+            return repo;
+          }
+          const splitName = repoURL.pathname.slice(1).split("/");
+          if (splitName.length !== 2) {
+            return repo;
+          }
+          return {
+            owner: splitName[0],
+            repo: splitName[1],
+          };
+        })
+        .filter((r) => {
+          return r.owner !== "" && r.repo !== "";
+        });
+    });
+  }
+
+  private async *loadAllCommitsForRepo(repo: {
+    owner: string;
+    repo: string;
+  }): AsyncGenerator<Commit> {
+    const iterator = this.gh.paginate.iterator(this.gh.rest.repos.listCommits, {
+      ...repo,
+      ...{ per_page: 500 },
+    });
+
+    for await (const { data: commits } of iterator) {
+      for (const commit of commits) {
+        yield commit;
+      }
+    }
+  }
+
+  private async recordEventsForRepo(repo: GithubRepoLocator) {
+    const artifact: IncompleteArtifact = {
+      name: `${repo.owner}/${repo.repo}`,
+      type: ArtifactType.GIT_REPOSITORY,
+      namespace: ArtifactNamespace.GITHUB,
+    };
+    for await (const commit of this.loadAllCommitsForRepo(repo)) {
+      const rawCommitTime =
+        commit.commit.committer?.date || commit.commit.author?.date;
+      if (!rawCommitTime) {
+        logger.warn(
+          `encountered a commit without a date. skipping for now. repo=${repo.owner}/${repo.repo}@${commit.sha}`,
+          {
+            owner: repo.owner,
+            repo: repo.repo,
+            sha: commit.sha,
+          },
+        );
+        continue;
+      }
+      const commitTime = DateTime.fromISO(rawCommitTime);
+      const event: IncompleteEvent = {
+        eventTime: commitTime,
+        eventType: EventType.COMMIT_CODE,
+        artifact: artifact,
+        amount: 0,
+        details: {
+          sha: commit.sha,
+        },
+      };
+
+      const contributor = this.contributorFromCommit(commit);
+      if (!contributor) {
+        logger.warn(
+          `encountered a commit without a login, email, or a name. recording commit without a contributor. repo=${repo.owner}/${repo.repo}@${commit.sha}`,
+          {
+            owner: repo.owner,
+            repo: repo.repo,
+            sha: commit.sha,
+          },
+        );
+      } else {
+        event.contributor = contributor;
+      }
+
+      this.recorder.record(event);
+    }
+
+    // Wait for all of the events for this repo to be recorded
+    await this.recorder.wait(EventType.COMMIT_CODE);
+  }
+
+  private contributorFromCommit(
+    commit: Commit,
+  ): IncompleteContributor | undefined {
+    const contributor: IncompleteContributor = {
+      name: "",
+      namespace: ContributorNamespace.GITHUB_USER,
+    };
+    if (commit.committer) {
+      contributor.name = commit.committer.login;
+    } else if (commit.author) {
+      contributor.name = commit.author.login;
+    }
+
+    if (!contributor.name) {
+      // We will need to resort to use the email of the user if we cannot find a
+      // name
+      contributor.namespace = ContributorNamespace.GIT_EMAIL;
+      if (commit.commit.committer?.email) {
+        contributor.name = commit.commit.committer.email;
+      } else if (commit.commit.author?.email) {
+        contributor.name = commit.commit.author.email;
+      }
+      if (!contributor.name) {
+        contributor.namespace = ContributorNamespace.GIT_NAME;
+        // If there's still nothing we will attempt to use a name
+        if (commit.commit.committer?.name) {
+          contributor.name = commit.commit.committer.name;
+        } else if (commit.commit.author?.name) {
+          contributor.name = commit.commit.author.name;
+        }
+        if (!contributor.name) {
+          return undefined;
+        }
+      }
+    }
+    return contributor;
+  }
+}
+
+export type LoadCommits = CommonArgs & {
+  skipExisting?: boolean;
+};
+
+export async function loadCommits(args: LoadCommits): Promise<void> {
+  logger.info("loading commits");
+
+  const octokit = new Octokit({ auth: GITHUB_TOKEN });
+  const recorder = new BatchEventRecorder(prismaClient);
+  const fetcher = new GithubCommitFetcher(prismaClient, octokit, recorder);
+
+  await fetcher.run();
+  logger.info("done");
+}

--- a/indexer/src/actions/github/fetch/commits.ts
+++ b/indexer/src/actions/github/fetch/commits.ts
@@ -11,7 +11,6 @@ import {
   ArtifactType,
   ContributorNamespace,
   EventType,
-  Prisma,
   PrismaClient,
 } from "@prisma/client";
 import { BatchEventRecorder } from "../../../recorder/recorder.js";
@@ -238,7 +237,7 @@ export type LoadCommits = CommonArgs & {
   skipExisting?: boolean;
 };
 
-export async function loadCommits(args: LoadCommits): Promise<void> {
+export async function loadCommits(_args: LoadCommits): Promise<void> {
   logger.info("loading commits");
 
   const octokit = new Octokit({ auth: GITHUB_TOKEN });

--- a/indexer/src/cli.ts
+++ b/indexer/src/cli.ts
@@ -22,6 +22,7 @@ import {
   ImportDailyContractUsage,
   importDailyContractUsage,
 } from "./actions/dune/index.js";
+import { LoadCommits, loadCommits } from "./actions/github/fetch/commits.js";
 import { DateTime } from "luxon";
 
 const callLibrary = async <Args>(
@@ -79,6 +80,14 @@ yargs(hideBin(process.argv))
         });
     },
     (argv) => handleError(importDailyContractUsage(argv)),
+  )
+  .command<LoadCommits>(
+    "loadCommits",
+    "Manually import commits",
+    (yags) => {
+      yags.option("skipExisting", { type: "boolean" });
+    },
+    (argv) => handleError(loadCommits(argv)),
   )
   .command<RunAutocrawlArgs>(
     "runAutocrawl",

--- a/indexer/src/db/artifacts.ts
+++ b/indexer/src/db/artifacts.ts
@@ -1,0 +1,37 @@
+import { Readable } from "stream";
+import { Prisma, PrismaClient } from "@prisma/client";
+
+export function streamFindAll(
+  prisma: PrismaClient,
+  batchSize: number,
+  where: Prisma.ArtifactWhereInput,
+): Readable {
+  let cursorId: number | undefined = undefined;
+
+  // Lazily stolen from: https://github.com/prisma/prisma/issues/5055
+  return new Readable({
+    objectMode: true,
+    highWaterMark: batchSize,
+    async read() {
+      try {
+        const items = await prisma.artifact.findMany({
+          where: where,
+          take: batchSize,
+          skip: cursorId ? 1 : 0,
+          cursor: cursorId ? { id: cursorId } : undefined,
+        });
+        for (const item of items) {
+          this.push(item);
+        }
+        if (items.length < batchSize) {
+          this.push(null);
+          return;
+        }
+        const item = items[items.length - 1];
+        cursorId = item.id;
+      } catch (err) {
+        this.destroy(err as any);
+      }
+    },
+  });
+}

--- a/indexer/src/recorder/actors.ts
+++ b/indexer/src/recorder/actors.ts
@@ -1,0 +1,147 @@
+import {
+  Artifact,
+  ArtifactNamespace,
+  Contributor,
+  ContributorNamespace,
+} from "@prisma/client";
+import {
+  IActorDirectory,
+  IncompleteArtifact,
+  IncompleteContributor,
+  IncompleteActor,
+  UnknownActor,
+} from "./types.js";
+
+type IdType = string | number;
+
+export class ActorLookup<
+  I extends IdType,
+  V extends IncompleteActor<N, M> & { id: I },
+  N extends string,
+  M extends string,
+> {
+  private incompleteLookup: Record<M, Record<N, V>>;
+  private idLookup: Record<I, V>;
+
+  constructor() {
+    this.incompleteLookup = {} as Record<M, Record<N, V>>;
+    this.idLookup = {} as Record<I, V>;
+  }
+
+  add(item: V) {
+    const namespaceLookup = this.getNamespaceLookup(item.namespace);
+    namespaceLookup[item.name] = item;
+
+    this.idLookup[item.id] = item;
+  }
+
+  private getNamespaceLookup(namespace: M) {
+    let namespaceLookup = this.incompleteLookup[namespace];
+    if (!namespaceLookup) {
+      this.incompleteLookup[namespace] = {} as Record<N, V>;
+      namespaceLookup = this.incompleteLookup[namespace];
+    }
+    return namespaceLookup;
+  }
+
+  byString(item: IncompleteActor<N, M>): V {
+    return this.getNamespaceLookup(item.namespace)[item.name];
+  }
+
+  byId(id: I): V {
+    return this.idLookup[id];
+  }
+
+  knownSetOf(actors: IncompleteActor<N, M>[]): V[] {
+    const known: V[] = [];
+    actors.forEach((actor) => {
+      const resolved = this.byString(actor);
+      if (resolved) {
+        known.push(resolved);
+      }
+    });
+    return known;
+  }
+
+  unknownSetOf<T extends IncompleteActor<N, M>>(actors: T[]): T[] {
+    return actors.filter((actor) => {
+      return !this.byString(actor);
+    });
+  }
+}
+
+export class InmemActorResolver implements IActorDirectory {
+  private artifactsLookup: ActorLookup<
+    number,
+    Artifact,
+    string,
+    ArtifactNamespace
+  >;
+  private contributorsLookup: ActorLookup<
+    number,
+    Contributor,
+    string,
+    ContributorNamespace
+  >;
+
+  constructor() {
+    this.artifactsLookup = new ActorLookup();
+    this.contributorsLookup = new ActorLookup();
+  }
+
+  async artifactFromId(id: number): Promise<Artifact> {
+    return this.artifactsLookup.byId(id);
+  }
+
+  async contributorFromId(id: number): Promise<Contributor> {
+    return this.contributorsLookup.byId(id);
+  }
+
+  async resolveArtifactId(artifact: IncompleteArtifact): Promise<number> {
+    const resolved = this.artifactsLookup.byString(artifact);
+    if (!resolved) {
+      throw new UnknownActor(
+        `Artifact unknown name=${artifact.name} namespace=${artifact.namespace}`,
+      );
+    }
+    return resolved.id;
+  }
+
+  async resolveContributorId(
+    contributor: IncompleteContributor,
+  ): Promise<number> {
+    const resolved = this.contributorsLookup.byString(contributor);
+    if (!resolved) {
+      throw new UnknownActor(
+        `Contributor unknown. name=${contributor.name} namespace=${contributor.namespace}`,
+      );
+    }
+    return resolved.id;
+  }
+
+  loadArtifact(artifact: Artifact) {
+    this.artifactsLookup.add(artifact);
+  }
+
+  loadContributor(contributor: Contributor) {
+    this.contributorsLookup.add(contributor);
+  }
+
+  knownArtifactsFrom(artifacts: IncompleteArtifact[]): Artifact[] {
+    return this.artifactsLookup.knownSetOf(artifacts);
+  }
+
+  unknownArtifactsFrom(artifacts: IncompleteArtifact[]): IncompleteArtifact[] {
+    return this.artifactsLookup.unknownSetOf(artifacts);
+  }
+
+  knownContributorsFrom(contributors: IncompleteContributor[]): Contributor[] {
+    return this.contributorsLookup.knownSetOf(contributors);
+  }
+
+  unknownContributorsFrom(
+    contributors: IncompleteContributor[],
+  ): IncompleteContributor[] {
+    return this.contributorsLookup.unknownSetOf(contributors);
+  }
+}

--- a/indexer/src/recorder/index.ts
+++ b/indexer/src/recorder/index.ts
@@ -1,0 +1,1 @@
+export * from "./types.js";

--- a/indexer/src/recorder/recorder.ts
+++ b/indexer/src/recorder/recorder.ts
@@ -1,0 +1,303 @@
+import {
+  Artifact,
+  ArtifactNamespace,
+  Contributor,
+  ContributorNamespace,
+  Event,
+  EventType,
+  Prisma,
+  PrismaClient,
+} from "@prisma/client";
+import {
+  IEventRecorder,
+  IncompleteEvent,
+  IEventTypeStrategy,
+  generateEventTypeStrategy,
+  IncompleteArtifact,
+  IncompleteContributor,
+} from "./types.js";
+import { InmemActorResolver } from "./actors.js";
+import { UniqueArray, asyncBatch } from "../utils/array.js";
+import { streamFindAll as allEvents } from "../db/events.js";
+import { streamFindAll as allContributors } from "../db/contributors.js";
+import { streamFindAll as allArtifacts } from "../db/artifacts.js";
+import { logger } from "../utils/logger.js";
+import _ from "lodash";
+
+export interface BatchEventRecorderOptions {
+  maxBatchSize: number;
+}
+
+const defaultBatchEventRecorderOptions: BatchEventRecorderOptions = {
+  maxBatchSize: 5000,
+};
+
+export class BatchEventRecorder implements IEventRecorder {
+  private eventTypeStrategies: Record<string, IEventTypeStrategy>;
+  private eventTypeQueues: Record<string, IncompleteEvent[]>;
+  private options: BatchEventRecorderOptions;
+  private actorDirectory: InmemActorResolver;
+  private prisma: PrismaClient;
+  private artifactNamespaces: ArtifactNamespace[];
+  private contributorNamespaces: ContributorNamespace[];
+  private actorsLoaded: boolean;
+
+  constructor(prisma: PrismaClient, options?: BatchEventRecorderOptions) {
+    this.prisma = prisma;
+    this.eventTypeStrategies = {};
+    this.eventTypeQueues = {};
+    this.actorDirectory = new InmemActorResolver();
+    this.options = _.merge(defaultBatchEventRecorderOptions, options);
+    this.artifactNamespaces = [];
+    this.contributorNamespaces = [];
+    this.actorsLoaded = false;
+  }
+
+  setActorScope(
+    artifactNamespaces: ArtifactNamespace[],
+    contributorNamespaces: ContributorNamespace[],
+  ) {
+    this.artifactNamespaces = artifactNamespaces;
+    this.contributorNamespaces = contributorNamespaces;
+  }
+
+  private async loadActors(): Promise<void> {
+    if (this.artifactNamespaces.length === 0) {
+      throw new Error("scope of recording must be set");
+    }
+
+    if (this.contributorNamespaces.length === 0) {
+      throw new Error("scope of recording must be set");
+    }
+
+    logger.debug("loading all artifacts and contributors");
+
+    // Load all of the artifacts
+    const artifacts = await allArtifacts(
+      this.prisma,
+      this.options.maxBatchSize,
+      {
+        namespace: {
+          in: this.artifactNamespaces,
+        },
+      },
+    );
+
+    let aCount = 0;
+    for await (const raw of artifacts) {
+      const artifact = raw as Artifact;
+      this.actorDirectory.loadArtifact(artifact);
+      aCount += 1;
+    }
+    logger.debug(`loaded ${aCount} artifacts`);
+
+    // Load all of the contributors
+    const contributors = await allContributors(
+      this.prisma,
+      this.options.maxBatchSize,
+      {
+        namespace: {
+          in: this.contributorNamespaces,
+        },
+      },
+    );
+
+    let cCount = 0;
+    for await (const raw of contributors) {
+      const contributor = raw as Contributor;
+      this.actorDirectory.loadContributor(contributor);
+      cCount += 1;
+    }
+    logger.debug(`loaded ${cCount} contributors`);
+    this.actorsLoaded = true;
+  }
+
+  // Records events into a queue and periodically flushes that queue as
+  // transactions to the database.
+  registerEventType(eventType: EventType, strategy: IEventTypeStrategy): void {
+    this.eventTypeStrategies[eventType] = strategy;
+  }
+
+  record(event: IncompleteEvent): void {
+    // Queue an event for writing
+    const queue = this.getEventTypeQueue(event.eventType);
+    queue.push(event);
+  }
+
+  private getEventTypeStrategy(eventType: EventType): IEventTypeStrategy {
+    const strategy = this.eventTypeStrategies[eventType];
+    if (!strategy) {
+      return generateEventTypeStrategy(eventType);
+    }
+    return strategy;
+  }
+
+  async waitAll(): Promise<void[]> {
+    // Wait for all queues to complete
+    return Promise.all(
+      Object.keys(this.eventTypeQueues).map((eventType) => {
+        return this.wait(eventType as EventType);
+      }),
+    );
+  }
+
+  async wait(eventType: EventType): Promise<void> {
+    if (!this.actorsLoaded) {
+      await this.loadActors();
+    }
+    // Wait for a specific event type queue to complete
+    const queue = this.getEventTypeQueue(eventType);
+
+    if (queue.length === 0) {
+      return;
+    }
+    this.eventTypeQueues[eventType] = [];
+
+    logger.info(`emptying queue for ${eventType} with ${queue.length} items`);
+
+    // Get the date range for the currently queued items
+    let startDate = queue[0].eventTime;
+    let endDate = queue[0].eventTime;
+    queue.forEach((event) => {
+      if (startDate > event.eventTime) {
+        startDate = event.eventTime;
+      }
+      if (endDate < event.eventTime) {
+        endDate = event.eventTime;
+      }
+    });
+
+    // Get event type strategy
+    const strategy = this.getEventTypeStrategy(eventType);
+    const where = strategy.all(this.actorDirectory);
+    where.eventTime = {
+      gte: startDate.toJSDate(),
+      lte: endDate.toJSDate(),
+    };
+
+    // Find existing events (for idempotency)
+    const existingEvents = allEvents(
+      this.prisma,
+      this.options.maxBatchSize,
+      where,
+    );
+    const existingEventMap: { [id: string]: Event } = {};
+
+    for await (const raw of existingEvents) {
+      const event = raw as Event;
+      existingEventMap[await strategy.idFromEvent(this.actorDirectory, event)] =
+        event;
+    }
+
+    const newEvents = [];
+    const queuedArtifacts: UniqueArray<IncompleteArtifact> = new UniqueArray(
+      (a) => `${a.name}::${a.namespace}`,
+    );
+    const queuedContributors: UniqueArray<IncompleteContributor> =
+      new UniqueArray((c) => `${c.name}::${c.namespace}`);
+
+    // Filter duplicates
+    for (const event of queue) {
+      const incompleteId = await strategy.idFromIncompleteEvent(
+        this.actorDirectory,
+        event,
+      );
+      const existing = existingEventMap[incompleteId];
+      if (!existing) {
+        queuedArtifacts.push(event.artifact);
+        if (event.contributor) {
+          queuedContributors.push(event.contributor);
+        }
+        newEvents.push(event);
+      }
+    }
+    logger.debug(`skipping ${queue.length - newEvents.length} existing events`);
+
+    // Create all of the new actors involved
+    const newArtifacts = this.actorDirectory.unknownArtifactsFrom(
+      queuedArtifacts.items(),
+    );
+    const newContributors = this.actorDirectory.unknownContributorsFrom(
+      queuedContributors.items(),
+    );
+
+    // Write all the new artifacts
+    await asyncBatch(newArtifacts, this.options.maxBatchSize, async (batch) => {
+      logger.debug("writing new artifacts");
+      return this.prisma.artifact.createMany({
+        data: batch.map((a) => {
+          return {
+            name: a.name,
+            namespace: a.namespace,
+            type: a.type,
+          };
+        }),
+      });
+    });
+
+    // Write all the new contributors
+    await asyncBatch(
+      newContributors,
+      this.options.maxBatchSize,
+      async (batch) => {
+        logger.debug("writing new contributors");
+        await this.prisma.contributor.createMany({
+          data: batch.map((a) => {
+            return {
+              name: a.name,
+              namespace: a.namespace,
+            };
+          }),
+        });
+      },
+    );
+
+    // Load all of the actors again. We can improve this later
+    await this.loadActors();
+
+    await asyncBatch(
+      newEvents,
+      this.options.maxBatchSize,
+      async (batch, batchLength) => {
+        logger.info(`preparing to write a batch of ${batchLength} events`);
+        const events: Prisma.EventCreateManyInput[] = await Promise.all(
+          batch.map(async (e) => {
+            const artifactId = await this.actorDirectory.resolveArtifactId(
+              e.artifact,
+            );
+            let contributorId: number | null = null;
+            if (e.contributor) {
+              contributorId = await this.actorDirectory.resolveContributorId(
+                e.contributor,
+              );
+            }
+            const input: Prisma.EventCreateManyInput = {
+              eventTime: e.eventTime.toJSDate(),
+              artifactId: artifactId,
+              contributorId: contributorId,
+              eventType: e.eventType,
+              amount: e.amount,
+            };
+            if (e.details) {
+              input.details = e.details as Prisma.JsonObject;
+            }
+            return input;
+          }),
+        );
+
+        return this.prisma.event.createMany({
+          data: events,
+        });
+      },
+    );
+  }
+
+  protected getEventTypeQueue(eventType: EventType): IncompleteEvent[] {
+    let queue = this.eventTypeQueues[eventType];
+    if (!queue) {
+      this.eventTypeQueues[eventType] = [];
+      queue = this.eventTypeQueues[eventType];
+    }
+    return queue;
+  }
+}

--- a/indexer/src/recorder/types.ts
+++ b/indexer/src/recorder/types.ts
@@ -1,0 +1,167 @@
+import {
+  Artifact,
+  Contributor,
+  EventType,
+  Event,
+  Prisma,
+} from "@prisma/client";
+import _ from "lodash";
+import { DateTime } from "luxon";
+
+export class UnknownActor extends Error {
+  constructor(message: string) {
+    super(message);
+
+    Object.setPrototypeOf(this, UnknownActor.prototype);
+  }
+}
+
+export interface IEventRecorder {
+  // A generic event recorder that will automatically handle batching writes for
+  // events and also resolving artifacts and contributors (and automatically
+  // create any that we may need). This is so we don't have to manually control
+  // many of the batching calls necessary to make this work reliably with the
+  // databases, which apparently can be finicky. It also makes it a bit more
+  // generic for us to load events.
+  registerEventType(eventType: EventType, strategy: IEventTypeStrategy): void;
+
+  // Record a single event. These are batched
+  record(event: IncompleteEvent): void;
+
+  setActorScope(
+    artifactNamespaces: string[],
+    contributorNamespaces: string[],
+  ): void;
+
+  // Call this when you're done recording
+  waitAll(): Promise<void[]>;
+
+  wait(eventType: EventType): Promise<void>;
+}
+
+export interface IActorDirectory {
+  artifactFromId(id: number): Promise<Artifact>;
+  contributorFromId(id: number): Promise<Contributor>;
+
+  resolveContributorId(contributor: IncompleteContributor): Promise<number>;
+  resolveArtifactId(artifact: IncompleteArtifact): Promise<number>;
+
+  knownArtifactsFrom(artifacts: IncompleteArtifact[]): Artifact[];
+  knownContributorsFrom(contributors: IncompleteContributor[]): Contributor[];
+
+  unknownArtifactsFrom(artifacts: IncompleteArtifact[]): IncompleteArtifact[];
+  unknownContributorsFrom(
+    contributors: IncompleteContributor[],
+  ): IncompleteContributor[];
+}
+
+export interface IEventTypeStrategy {
+  // This library assumes that each event type has a way of determining
+  // uniqueness with events. This is for idempotency's sake. Most of the time
+  // this likely doesn't need to be used.
+  //uniqueEventsQueryFor(resolver: IActorResolver, events: IncompleteEvent[]): Prisma.EventWhereInput;
+
+  // This is the query to use to get all of the events of a specific EventType
+  all(directory: IActorDirectory): Prisma.EventWhereInput;
+
+  idFromEvent(directory: IActorDirectory, event: Event): Promise<string>;
+
+  idFromIncompleteEvent(
+    directory: IActorDirectory,
+    event: IncompleteEvent,
+  ): Promise<string>;
+}
+
+export type IncompleteActor<N, M> = {
+  name: N;
+  namespace: M;
+};
+
+export type IncompleteArtifact = Pick<Artifact, "name" | "namespace" | "type"> &
+  Partial<Artifact>;
+export type IncompleteContributor = Pick<Contributor, "name" | "namespace"> &
+  Partial<Contributor>;
+
+export type IncompleteEvent = {
+  eventTime: DateTime;
+  eventType: EventType;
+  artifact: IncompleteArtifact;
+  contributor?: IncompleteContributor;
+  amount: number;
+  details?: object;
+};
+
+export class BasicEventTypeStrategy implements IEventTypeStrategy {
+  private allQuery: Prisma.EventWhereInput;
+  private eventIdFun: (
+    directory: IActorDirectory,
+    event: Event,
+  ) => Promise<string>;
+  private incompleteIdFunc: (
+    directory: IActorDirectory,
+    event: IncompleteEvent,
+  ) => Promise<string>;
+
+  constructor(
+    allQuery: Prisma.EventWhereInput,
+    eventIdFunc: (directory: IActorDirectory, event: Event) => Promise<string>,
+    incompleteIdFunc: (
+      directory: IActorDirectory,
+      event: IncompleteEvent,
+    ) => Promise<string>,
+  ) {
+    this.allQuery = allQuery;
+    this.eventIdFun = eventIdFunc;
+    this.incompleteIdFunc = incompleteIdFunc;
+  }
+
+  idFromEvent(directory: IActorDirectory, event: Event): Promise<string> {
+    return this.eventIdFun(directory, event);
+  }
+
+  idFromIncompleteEvent(
+    directory: IActorDirectory,
+    event: IncompleteEvent,
+  ): Promise<string> {
+    return this.incompleteIdFunc(directory, event);
+  }
+
+  all(_directory: IActorDirectory): Prisma.EventWhereInput {
+    return _.cloneDeep(this.allQuery);
+  }
+}
+
+export function generateEventTypeStrategy(
+  eventType: EventType,
+): IEventTypeStrategy {
+  return new BasicEventTypeStrategy(
+    {
+      eventType: eventType,
+    },
+    async (directory, event) => {
+      const artifact = await directory.artifactFromId(event.artifactId);
+      const artifactStr = `${artifact.name}::${artifact.namespace}`;
+
+      let contributorStr = "";
+      if (event.contributorId) {
+        const contributor = await directory.contributorFromId(
+          event.contributorId,
+        );
+        contributorStr = `${contributor.name}::${contributor.namespace}`;
+      }
+      // by default the "unique id" will just be the time, event type, and artifact id concatenated
+      return `${event.eventTime.toISOString()}::${
+        event.eventType
+      }::${artifactStr}:${contributorStr}`;
+    },
+    async (directory, event) => {
+      let contributorStr = "";
+      if (event.contributor) {
+        contributorStr = `${event.contributor.name}::${event.contributor.namespace}`;
+      }
+      return `${event.eventTime.toUTC().toISO()}::${event.eventType}::${
+        event.artifact.name
+      }::${event.artifact.namespace}::${contributorStr}`;
+    },
+  );
+}

--- a/indexer/src/utils/array.ts
+++ b/indexer/src/utils/array.ts
@@ -24,3 +24,36 @@ export class UniqueArray<T> {
     return _.cloneDeep(this.arr);
   }
 }
+
+/**
+ * asyncBatch creates batches of a given array for processing. This function
+ * awaits the callback for every batch.
+ *
+ * @param arr - The array to process in batches
+ * @param batchSize - The batch size
+ * @param cb - The async callback
+ * @returns
+ */
+export async function asyncBatch<T, R>(
+  arr: T[],
+  batchSize: number,
+  cb: (batch: T[], batchLength: number, batchNumber: number) => Promise<R>,
+): Promise<R[]> {
+  let batch = [];
+  let batchNumber = 0;
+  const results = [];
+  for (const item of arr) {
+    batch.push(item);
+
+    if (batch.length >= batchSize) {
+      results.push(await cb(batch, batch.length, batchNumber));
+      batchNumber += 1;
+      batch = [];
+    }
+  }
+  if (batch.length > 0) {
+    results.push(await cb(batch, batch.length, batchNumber));
+    batch = [];
+  }
+  return results;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         version: 5.14.3(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.17)(react-dom@18.2.0)(react@18.2.0)
       '@plasmicapp/loader-nextjs':
         specifier: ^1.0.302
-        version: 1.0.302(next@13.4.19)(react-dom@18.2.0)(react@18.2.0)
+        version: 1.0.302(next@13.4.13)(react-dom@18.2.0)(react@18.2.0)
       '@supabase/supabase-js':
         specifier: ^2.32.0
         version: 2.32.0
@@ -55,7 +55,7 @@ importers:
         version: 1.11.9
       next:
         specifier: latest
-        version: 13.4.19(@babel/core@7.22.10)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.13(@babel/core@7.22.10)(react-dom@18.2.0)(react@18.2.0)
       random-words:
         specifier: ^2.0.0
         version: 2.0.0
@@ -150,6 +150,9 @@ importers:
       '@cowprotocol/ts-dune-client':
         specifier: ^0.0.2
         version: 0.0.2
+      '@octokit/types':
+        specifier: ^11.1.0
+        version: 11.1.0
       '@prisma/client':
         specifier: ^5.1.1
         version: 5.1.1(prisma@5.1.1)
@@ -177,6 +180,9 @@ importers:
       npm-registry-fetch:
         specifier: ^15.0.0
         version: 15.0.0
+      octokit:
+        specifier: ^3.1.0
+        version: 3.1.0
       ora:
         specifier: ^7.0.1
         version: 7.0.1
@@ -1288,8 +1294,8 @@ packages:
       react-is: 18.2.0
     dev: false
 
-  /@next/env@13.4.19:
-    resolution: {integrity: sha512-FsAT5x0jF2kkhNkKkukhsyYOrRqtSxrEhfliniIq0bwWbuXLgyt3Gv0Ml+b91XwjwArmuP7NxCiGd++GGKdNMQ==}
+  /@next/env@13.4.13:
+    resolution: {integrity: sha512-fwz2QgVg08v7ZL7KmbQBLF2PubR/6zQdKBgmHEl3BCyWTEDsAQEijjw2gbFhI1tcKfLdOOJUXntz5vZ4S0Polg==}
     dev: false
 
   /@next/eslint-plugin-next@13.4.12:
@@ -1298,8 +1304,8 @@ packages:
       glob: 7.1.7
     dev: true
 
-  /@next/swc-darwin-arm64@13.4.19:
-    resolution: {integrity: sha512-vv1qrjXeGbuF2mOkhkdxMDtv9np7W4mcBtaDnHU+yJG+bBwa6rYsYSCI/9Xm5+TuF5SbZbrWO6G1NfTh1TMjvQ==}
+  /@next/swc-darwin-arm64@13.4.13:
+    resolution: {integrity: sha512-ZptVhHjzUuivnXMNCJ6lER33HN7lC+rZ01z+PM10Ows21NHFYMvGhi5iXkGtBDk6VmtzsbqnAjnx4Oz5um0FjA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -1307,8 +1313,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-darwin-x64@13.4.19:
-    resolution: {integrity: sha512-jyzO6wwYhx6F+7gD8ddZfuqO4TtpJdw3wyOduR4fxTUCm3aLw7YmHGYNjS0xRSYGAkLpBkH1E0RcelyId6lNsw==}
+  /@next/swc-darwin-x64@13.4.13:
+    resolution: {integrity: sha512-t9nTiWCLApw8W4G1kqJyYP7y6/7lyal3PftmRturIxAIBlZss9wrtVN8nci50StDHmIlIDxfguYIEGVr9DbFTg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -1316,8 +1322,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-arm64-gnu@13.4.19:
-    resolution: {integrity: sha512-vdlnIlaAEh6H+G6HrKZB9c2zJKnpPVKnA6LBwjwT2BTjxI7e0Hx30+FoWCgi50e+YO49p6oPOtesP9mXDRiiUg==}
+  /@next/swc-linux-arm64-gnu@13.4.13:
+    resolution: {integrity: sha512-xEHUqC8eqR5DHe8SOmMnDU1K3ggrJ28uIKltrQAwqFSSSmzjnN/XMocZkcVhuncuxYrpbri0iMQstRyRVdQVWg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -1325,8 +1331,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-arm64-musl@13.4.19:
-    resolution: {integrity: sha512-aU0HkH2XPgxqrbNRBFb3si9Ahu/CpaR5RPmN2s9GiM9qJCiBBlZtRTiEca+DC+xRPyCThTtWYgxjWHgU7ZkyvA==}
+  /@next/swc-linux-arm64-musl@13.4.13:
+    resolution: {integrity: sha512-sNf3MnLAm8rquSSAoeD9nVcdaDeRYOeey4stOWOyWIgbBDtP+C93amSgH/LPTDoUV7gNiU6f+ghepTjTjRgIUQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -1334,8 +1340,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-x64-gnu@13.4.19:
-    resolution: {integrity: sha512-htwOEagMa/CXNykFFeAHHvMJeqZfNQEoQvHfsA4wgg5QqGNqD5soeCer4oGlCol6NGUxknrQO6VEustcv+Md+g==}
+  /@next/swc-linux-x64-gnu@13.4.13:
+    resolution: {integrity: sha512-WhcRaJJSHyx9OWmKjjz+OWHumiPZWRqmM/09Bt7Up4UqUJFFhGExeztR4trtv3rflvULatu9IH/nTV8fUUgaMA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -1343,8 +1349,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-x64-musl@13.4.19:
-    resolution: {integrity: sha512-4Gj4vvtbK1JH8ApWTT214b3GwUh9EKKQjY41hH/t+u55Knxi/0wesMzwQRhppK6Ddalhu0TEttbiJ+wRcoEj5Q==}
+  /@next/swc-linux-x64-musl@13.4.13:
+    resolution: {integrity: sha512-+Y4LLhOWWZQIDKVwr2R17lq2KSN0F1c30QVgGIWfnjjHpH8nrIWHEndhqYU+iFuW8It78CiJjQKTw4f51HD7jA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -1352,8 +1358,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-arm64-msvc@13.4.19:
-    resolution: {integrity: sha512-bUfDevQK4NsIAHXs3/JNgnvEY+LRyneDN788W2NYiRIIzmILjba7LaQTfihuFawZDhRtkYCv3JDC3B4TwnmRJw==}
+  /@next/swc-win32-arm64-msvc@13.4.13:
+    resolution: {integrity: sha512-rWurdOR20uxjfqd1X9vDAgv0Jb26KjyL8akF9CBeFqX8rVaBAnW/Wf6A2gYEwyYY4Bai3T7p1kro6DFrsvBAAw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -1361,8 +1367,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-ia32-msvc@13.4.19:
-    resolution: {integrity: sha512-Y5kikILFAr81LYIFaw6j/NrOtmiM4Sf3GtOc0pn50ez2GCkr+oejYuKGcwAwq3jiTKuzF6OF4iT2INPoxRycEA==}
+  /@next/swc-win32-ia32-msvc@13.4.13:
+    resolution: {integrity: sha512-E8bSPwRuY5ibJ3CzLQmJEt8qaWrPYuUTwnrwygPUEWoLzD5YRx9SD37oXRdU81TgGwDzCxpl7z5Nqlfk50xAog==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
@@ -1370,8 +1376,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-x64-msvc@13.4.19:
-    resolution: {integrity: sha512-YzA78jBDXMYiINdPdJJwGgPNT3YqBNNGhsthsDoWHL9p24tEJn9ViQf/ZqTbwSpX/RrkPupLfuuTH2sf73JBAw==}
+  /@next/swc-win32-x64-msvc@13.4.13:
+    resolution: {integrity: sha512-4KlyC6jWRubPnppgfYsNTPeWfGCxtWLh5vaOAW/kdzAk9widqho8Qb5S4K2vHmal1tsURi7Onk2MMCV1phvyqA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -1413,6 +1419,244 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
       semver: 7.5.4
+    dev: false
+
+  /@octokit/app@14.0.0:
+    resolution: {integrity: sha512-g/zDXttroZ9Se08shK0d0d/j0cgSA+h4WV7qGUevNEM0piNBkIlfb4Fm6bSwCNAZhNf72mBgERmYOoxicPkqdw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/auth-app': 6.0.0
+      '@octokit/auth-unauthenticated': 5.0.0
+      '@octokit/core': 5.0.0
+      '@octokit/oauth-app': 6.0.0
+      '@octokit/plugin-paginate-rest': 8.0.0(@octokit/core@5.0.0)
+      '@octokit/types': 11.1.0
+      '@octokit/webhooks': 12.0.3
+    dev: false
+
+  /@octokit/auth-app@6.0.0:
+    resolution: {integrity: sha512-OKct7Rukf3g9DjpzcpdacQsdmd6oPrJ7fZND22JkjzhDvfhttUOnmh+qPS4kHhaNNyTxqSThnfrUWvkqNLd1nw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/auth-oauth-app': 7.0.0
+      '@octokit/auth-oauth-user': 4.0.0
+      '@octokit/request': 8.1.1
+      '@octokit/request-error': 5.0.0
+      '@octokit/types': 11.1.0
+      deprecation: 2.3.1
+      lru-cache: 10.0.0
+      universal-github-app-jwt: 1.1.1
+      universal-user-agent: 6.0.0
+    dev: false
+
+  /@octokit/auth-oauth-app@7.0.0:
+    resolution: {integrity: sha512-8JvJEXGoEqrbzLwt3SwIUvkDd+1wrM8up0KawvDIElB8rbxPbvWppGO0SLKAWSJ0q8ILcVq+mWck6pDcZ3a9KA==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/auth-oauth-device': 6.0.0
+      '@octokit/auth-oauth-user': 4.0.0
+      '@octokit/request': 8.1.1
+      '@octokit/types': 11.1.0
+      '@types/btoa-lite': 1.0.0
+      btoa-lite: 1.0.0
+      universal-user-agent: 6.0.0
+    dev: false
+
+  /@octokit/auth-oauth-device@6.0.0:
+    resolution: {integrity: sha512-Zgf/LKhwWk54rJaTGYVYtbKgUty+ouil6VQeRd+pCw7Gd0ECoSWaZuHK6uDGC/HtnWHjpSWFhzxPauDoHcNRtg==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/oauth-methods': 4.0.0
+      '@octokit/request': 8.1.1
+      '@octokit/types': 11.1.0
+      universal-user-agent: 6.0.0
+    dev: false
+
+  /@octokit/auth-oauth-user@4.0.0:
+    resolution: {integrity: sha512-VOm5aIkVGHaOhIvsF/4YmSjoYDzzrKbbYkdSEO0KqHK7I8SlO3ZndSikQ1fBlNPUEH0ve2BOTxLrVvI1qBf9/Q==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/auth-oauth-device': 6.0.0
+      '@octokit/oauth-methods': 4.0.0
+      '@octokit/request': 8.1.1
+      '@octokit/types': 11.1.0
+      btoa-lite: 1.0.0
+      universal-user-agent: 6.0.0
+    dev: false
+
+  /@octokit/auth-token@4.0.0:
+    resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
+    engines: {node: '>= 18'}
+    dev: false
+
+  /@octokit/auth-unauthenticated@5.0.0:
+    resolution: {integrity: sha512-AjOI6FNB2dweJ85p6rf7D4EhE4y6VBcwYfX/7KJkR5Q9fD9ET6NABAjajUTSNFfCxmNIaQgISggZ3pkgwtTqsA==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/request-error': 5.0.0
+      '@octokit/types': 11.1.0
+    dev: false
+
+  /@octokit/core@5.0.0:
+    resolution: {integrity: sha512-YbAtMWIrbZ9FCXbLwT9wWB8TyLjq9mxpKdgB3dUNxQcIVTf9hJ70gRPwAcqGZdY6WdJPZ0I7jLaaNDCiloGN2A==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/auth-token': 4.0.0
+      '@octokit/graphql': 7.0.1
+      '@octokit/request': 8.1.1
+      '@octokit/request-error': 5.0.0
+      '@octokit/types': 11.1.0
+      before-after-hook: 2.2.3
+      universal-user-agent: 6.0.0
+    dev: false
+
+  /@octokit/endpoint@9.0.0:
+    resolution: {integrity: sha512-szrQhiqJ88gghWY2Htt8MqUDO6++E/EIXqJ2ZEp5ma3uGS46o7LZAzSLt49myB7rT+Hfw5Y6gO3LmOxGzHijAQ==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/types': 11.1.0
+      is-plain-object: 5.0.0
+      universal-user-agent: 6.0.0
+    dev: false
+
+  /@octokit/graphql@7.0.1:
+    resolution: {integrity: sha512-T5S3oZ1JOE58gom6MIcrgwZXzTaxRnxBso58xhozxHpOqSTgDS6YNeEUvZ/kRvXgPrRz/KHnZhtb7jUMRi9E6w==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/request': 8.1.1
+      '@octokit/types': 11.1.0
+      universal-user-agent: 6.0.0
+    dev: false
+
+  /@octokit/oauth-app@6.0.0:
+    resolution: {integrity: sha512-bNMkS+vJ6oz2hCyraT9ZfTpAQ8dZNqJJQVNaKjPLx4ue5RZiFdU1YWXguOPR8AaSHS+lKe+lR3abn2siGd+zow==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/auth-oauth-app': 7.0.0
+      '@octokit/auth-oauth-user': 4.0.0
+      '@octokit/auth-unauthenticated': 5.0.0
+      '@octokit/core': 5.0.0
+      '@octokit/oauth-authorization-url': 6.0.2
+      '@octokit/oauth-methods': 4.0.0
+      '@types/aws-lambda': 8.10.119
+      universal-user-agent: 6.0.0
+    dev: false
+
+  /@octokit/oauth-authorization-url@6.0.2:
+    resolution: {integrity: sha512-CdoJukjXXxqLNK4y/VOiVzQVjibqoj/xHgInekviUJV73y/BSIcwvJ/4aNHPBPKcPWFnd4/lO9uqRV65jXhcLA==}
+    engines: {node: '>= 18'}
+    dev: false
+
+  /@octokit/oauth-methods@4.0.0:
+    resolution: {integrity: sha512-dqy7BZLfLbi3/8X8xPKUKZclMEK9vN3fK5WF3ortRvtplQTszFvdAGbTo71gGLO+4ZxspNiLjnqdd64Chklf7w==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/oauth-authorization-url': 6.0.2
+      '@octokit/request': 8.1.1
+      '@octokit/request-error': 5.0.0
+      '@octokit/types': 11.1.0
+      btoa-lite: 1.0.0
+    dev: false
+
+  /@octokit/openapi-types@18.0.0:
+    resolution: {integrity: sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw==}
+    dev: false
+
+  /@octokit/plugin-paginate-graphql@4.0.0(@octokit/core@5.0.0):
+    resolution: {integrity: sha512-7HcYW5tP7/Z6AETAPU14gp5H5KmCPT3hmJrS/5tO7HIgbwenYmgw4OY9Ma54FDySuxMwD+wsJlxtuGWwuZuItA==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '>=5'
+    dependencies:
+      '@octokit/core': 5.0.0
+    dev: false
+
+  /@octokit/plugin-paginate-rest@8.0.0(@octokit/core@5.0.0):
+    resolution: {integrity: sha512-2xZ+baZWUg+qudVXnnvXz7qfrTmDeYPCzangBVq/1gXxii/OiS//4shJp9dnCCvj1x+JAm9ji1Egwm1BA47lPQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '>=5'
+    dependencies:
+      '@octokit/core': 5.0.0
+      '@octokit/types': 11.1.0
+    dev: false
+
+  /@octokit/plugin-rest-endpoint-methods@9.0.0(@octokit/core@5.0.0):
+    resolution: {integrity: sha512-KquMF/VB1IkKNiVnzJKspY5mFgGyLd7HzdJfVEGTJFzqu9BRFNWt+nwTCMuUiWc72gLQhRWYubTwOkQj+w/1PA==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '>=5'
+    dependencies:
+      '@octokit/core': 5.0.0
+      '@octokit/types': 11.1.0
+    dev: false
+
+  /@octokit/plugin-retry@6.0.0(@octokit/core@5.0.0):
+    resolution: {integrity: sha512-a1/A4A+PB1QoAHQfLJxGHhLfSAT03bR1jJz3GgQJZvty2ozawFWs93MiBQXO7SL2YbO7CIq0Goj4qLOBj8JeMQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '>=5'
+    dependencies:
+      '@octokit/core': 5.0.0
+      '@octokit/request-error': 5.0.0
+      '@octokit/types': 11.1.0
+      bottleneck: 2.19.5
+    dev: false
+
+  /@octokit/plugin-throttling@7.0.0(@octokit/core@5.0.0):
+    resolution: {integrity: sha512-KL2k/d0uANc8XqP5S64YcNFCudR3F5AaKO39XWdUtlJIjT9Ni79ekWJ6Kj5xvAw87udkOMEPcVf9xEge2+ahew==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': ^5.0.0
+    dependencies:
+      '@octokit/core': 5.0.0
+      '@octokit/types': 11.1.0
+      bottleneck: 2.19.5
+    dev: false
+
+  /@octokit/request-error@5.0.0:
+    resolution: {integrity: sha512-1ue0DH0Lif5iEqT52+Rf/hf0RmGO9NWFjrzmrkArpG9trFfDM/efx00BJHdLGuro4BR/gECxCU2Twf5OKrRFsQ==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/types': 11.1.0
+      deprecation: 2.3.1
+      once: 1.4.0
+    dev: false
+
+  /@octokit/request@8.1.1:
+    resolution: {integrity: sha512-8N+tdUz4aCqQmXl8FpHYfKG9GelDFd7XGVzyN8rc6WxVlYcfpHECnuRkgquzz+WzvHTK62co5di8gSXnzASZPQ==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/endpoint': 9.0.0
+      '@octokit/request-error': 5.0.0
+      '@octokit/types': 11.1.0
+      is-plain-object: 5.0.0
+      universal-user-agent: 6.0.0
+    dev: false
+
+  /@octokit/types@11.1.0:
+    resolution: {integrity: sha512-Fz0+7GyLm/bHt8fwEqgvRBWwIV1S6wRRyq+V6exRKLVWaKGsuy6H9QFYeBVDV7rK6fO3XwHgQOPxv+cLj2zpXQ==}
+    dependencies:
+      '@octokit/openapi-types': 18.0.0
+    dev: false
+
+  /@octokit/webhooks-methods@4.0.0:
+    resolution: {integrity: sha512-M8mwmTXp+VeolOS/kfRvsDdW+IO0qJ8kYodM/sAysk093q6ApgmBXwK1ZlUvAwXVrp/YVHp6aArj4auAxUAOFw==}
+    engines: {node: '>= 18'}
+    dev: false
+
+  /@octokit/webhooks-types@7.1.0:
+    resolution: {integrity: sha512-y92CpG4kFFtBBjni8LHoV12IegJ+KFxLgKRengrVjKmGE5XMeCuGvlfRe75lTRrgXaG6XIWJlFpIDTlkoJsU8w==}
+    dev: false
+
+  /@octokit/webhooks@12.0.3:
+    resolution: {integrity: sha512-8iG+/yza7hwz1RrQ7i7uGpK2/tuItZxZq1aTmeg2TNp2xTUB8F8lZF/FcZvyyAxT8tpDMF74TjFGCDACkf1kAQ==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/request-error': 5.0.0
+      '@octokit/webhooks-methods': 4.0.0
+      '@octokit/webhooks-types': 7.1.0
+      aggregate-error: 3.1.0
     dev: false
 
   /@pkgjs/parseargs@0.11.0:
@@ -1486,7 +1730,7 @@ packages:
       '@plasmicapp/isomorphic-unfetch': 1.0.2
     dev: false
 
-  /@plasmicapp/loader-nextjs@1.0.302(next@13.4.19)(react-dom@18.2.0)(react@18.2.0):
+  /@plasmicapp/loader-nextjs@1.0.302(next@13.4.13)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-A/P9LmJ/60yKai49pO1MJxTrDjUp/x+vC7ar/h9lMjOyXhYYsR3PSRWSrI36fhEZnbD2e8mEIrDRjpQ6hIjJeA==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -1498,7 +1742,7 @@ packages:
       '@plasmicapp/loader-edge': 1.0.35
       '@plasmicapp/loader-react': 1.0.283(react-dom@18.2.0)(react@18.2.0)
       '@plasmicapp/watcher': 1.0.72
-      next: 13.4.19(@babel/core@7.22.10)(react-dom@18.2.0)(react@18.2.0)
+      next: 13.4.13(@babel/core@7.22.10)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       server-only: 0.0.1
@@ -1770,6 +2014,10 @@ packages:
     resolution: {integrity: sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==}
     dev: true
 
+  /@types/aws-lambda@8.10.119:
+    resolution: {integrity: sha512-Vqm22aZrCvCd6I5g1SvpW151jfqwTzEZ7XJ3yZ6xaZG31nUEOEyzzVImjRcsN8Wi/QyPxId/x8GTtgIbsy8kEw==}
+    dev: false
+
   /@types/babel__core@7.20.1:
     resolution: {integrity: sha512-aACu/U/omhdk15O4Nfb+fHgH/z3QsfQzpnvRZhYhThms83ZnAOZz7zZAWO7mn2yyNQaA4xTO8GLK3uqFU4bYYw==}
     dependencies:
@@ -1798,6 +2046,10 @@ packages:
     dependencies:
       '@babel/types': 7.22.10
     dev: true
+
+  /@types/btoa-lite@1.0.0:
+    resolution: {integrity: sha512-wJsiX1tosQ+J5+bY5LrSahHxr2wT+uME5UDwdN1kg4frt40euqA+wzECkmq4t5QbveHiJepfdThgQrPw6KiSlg==}
+    dev: false
 
   /@types/graceful-fs@4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
@@ -1843,6 +2095,12 @@ packages:
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
     dev: true
+
+  /@types/jsonwebtoken@9.0.2:
+    resolution: {integrity: sha512-drE6uz7QBKq1fYqqoFKTDRdFCPHd5TCub75BM+D+cMx7NU9hUz7SESLfC2fSCXVFMO5Yj8sOWHuGqPgjc+fz0Q==}
+    dependencies:
+      '@types/node': 20.4.9
+    dev: false
 
   /@types/lodash@4.14.196:
     resolution: {integrity: sha512-22y3o88f4a94mKljsZcanlNWPzO0uBsBdzLAngf2tp533LzZcQzb6+eZPJ+vCTt+bqF2XnvT9gejTLsAcJAJyQ==}
@@ -2556,6 +2814,10 @@ packages:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
     dev: false
 
+  /before-after-hook@2.2.3:
+    resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
+    dev: false
+
   /big-integer@1.6.51:
     resolution: {integrity: sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==}
     engines: {node: '>=0.6'}
@@ -2577,6 +2839,10 @@ packages:
       buffer: 6.0.3
       inherits: 2.0.4
       readable-stream: 3.6.2
+    dev: false
+
+  /bottleneck@2.19.5:
+    resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
     dev: false
 
   /boxen@7.0.0:
@@ -2641,6 +2907,14 @@ packages:
     dependencies:
       node-int64: 0.4.0
     dev: true
+
+  /btoa-lite@1.0.0:
+    resolution: {integrity: sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==}
+    dev: false
+
+  /buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+    dev: false
 
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -3172,6 +3446,10 @@ packages:
     engines: {node: '>=0.4.0'}
     dev: true
 
+  /deprecation@2.3.1:
+    resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
+    dev: false
+
   /dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -3242,6 +3520,12 @@ packages:
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  /ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: false
 
   /electron-to-chromium@1.4.487:
     resolution: {integrity: sha512-XbCRs/34l31np/p33m+5tdBrdXu9jJkZxSbNxj5I0H1KtV2ZMSB+i/HYqDiRzHaFx2T5EdytjoBRe8QRJE2vQg==}
@@ -4491,6 +4775,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /is-port-reachable@4.0.0:
     resolution: {integrity: sha512-9UoipoxYmSk6Xy7QFgRv2HDyaysmgSG75TFQs6S+3pDM7ZhKTF/bskZV+0UlABHzKjNVhPjYCLfeZUEg1wXxig==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -5306,6 +5595,16 @@ packages:
     engines: {'0': node >= 0.2.0}
     dev: false
 
+  /jsonwebtoken@9.0.1:
+    resolution: {integrity: sha512-K8wx7eJ5TPvEjuiVSkv167EVboBDv9PZdDoF7BgeQnBLVvZWW9clr2PsQHVJDTKaEIH5JBIwHujGcHp7GgI2eg==}
+    engines: {node: '>=12', npm: '>=6'}
+    dependencies:
+      jws: 3.2.2
+      lodash: 4.17.21
+      ms: 2.1.3
+      semver: 7.5.4
+    dev: false
+
   /jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
@@ -5315,6 +5614,21 @@ packages:
       object.assign: 4.1.4
       object.values: 1.1.6
     dev: true
+
+  /jwa@1.4.1:
+    resolution: {integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==}
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+    dev: false
+
+  /jws@3.2.2:
+    resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
+    dependencies:
+      jwa: 1.4.1
+      safe-buffer: 5.2.1
+    dev: false
 
   /kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -5705,8 +6019,8 @@ packages:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
     dev: false
 
-  /next@13.4.19(@babel/core@7.22.10)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-HuPSzzAbJ1T4BD8e0bs6B9C1kWQ6gv8ykZoRWs5AQoiIuqbGHHdQO7Ljuvg05Q0Z24E2ABozHe6FxDvI6HfyAw==}
+  /next@13.4.13(@babel/core@7.22.10)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-A3YVbVDNeXLhWsZ8Nf6IkxmNlmTNz0yVg186NJ97tGZqPDdPzTrHotJ+A1cuJm2XfuWPrKOUZILl5iBQkIf8Jw==}
     engines: {node: '>=16.8.0'}
     hasBin: true
     peerDependencies:
@@ -5720,7 +6034,7 @@ packages:
       sass:
         optional: true
     dependencies:
-      '@next/env': 13.4.19
+      '@next/env': 13.4.13
       '@swc/helpers': 0.5.1
       busboy: 1.6.0
       caniuse-lite: 1.0.30001519
@@ -5731,15 +6045,15 @@ packages:
       watchpack: 2.4.0
       zod: 3.21.4
     optionalDependencies:
-      '@next/swc-darwin-arm64': 13.4.19
-      '@next/swc-darwin-x64': 13.4.19
-      '@next/swc-linux-arm64-gnu': 13.4.19
-      '@next/swc-linux-arm64-musl': 13.4.19
-      '@next/swc-linux-x64-gnu': 13.4.19
-      '@next/swc-linux-x64-musl': 13.4.19
-      '@next/swc-win32-arm64-msvc': 13.4.19
-      '@next/swc-win32-ia32-msvc': 13.4.19
-      '@next/swc-win32-x64-msvc': 13.4.19
+      '@next/swc-darwin-arm64': 13.4.13
+      '@next/swc-darwin-x64': 13.4.13
+      '@next/swc-linux-arm64-gnu': 13.4.13
+      '@next/swc-linux-arm64-musl': 13.4.13
+      '@next/swc-linux-x64-gnu': 13.4.13
+      '@next/swc-linux-x64-musl': 13.4.13
+      '@next/swc-win32-arm64-msvc': 13.4.13
+      '@next/swc-win32-ia32-msvc': 13.4.13
+      '@next/swc-win32-x64-msvc': 13.4.13
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -5915,6 +6229,22 @@ packages:
       define-properties: 1.2.0
       es-abstract: 1.22.1
     dev: true
+
+  /octokit@3.1.0:
+    resolution: {integrity: sha512-dmIH5D+edpb4/ASd6ZGo6BiRR1g4ytu8lG4f+6XN/2AW+CSuTsT0nj1d6rv/HKgoflMQ1+rb3KlVWcvrmgQZhw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/app': 14.0.0
+      '@octokit/core': 5.0.0
+      '@octokit/oauth-app': 6.0.0
+      '@octokit/plugin-paginate-graphql': 4.0.0(@octokit/core@5.0.0)
+      '@octokit/plugin-paginate-rest': 8.0.0(@octokit/core@5.0.0)
+      '@octokit/plugin-rest-endpoint-methods': 9.0.0(@octokit/core@5.0.0)
+      '@octokit/plugin-retry': 6.0.0(@octokit/core@5.0.0)
+      '@octokit/plugin-throttling': 7.0.0(@octokit/core@5.0.0)
+      '@octokit/request-error': 5.0.0
+      '@octokit/types': 11.1.0
+    dev: false
 
   /on-headers@1.0.2:
     resolution: {integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==}
@@ -7371,6 +7701,17 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
       imurmurhash: 0.1.4
+    dev: false
+
+  /universal-github-app-jwt@1.1.1:
+    resolution: {integrity: sha512-G33RTLrIBMFmlDV4u4CBF7dh71eWwykck4XgaxaIVeZKOYZRAAxvcGMRFTUclVY6xoUPQvO4Ne5wKGxYm/Yy9w==}
+    dependencies:
+      '@types/jsonwebtoken': 9.0.2
+      jsonwebtoken: 9.0.1
+    dev: false
+
+  /universal-user-agent@6.0.0:
+    resolution: {integrity: sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==}
     dev: false
 
   /universalify@0.2.0:


### PR DESCRIPTION
This is a bit of a large PR but mostly cause I took some of the things I learned from pull the contract data and made a (hopefully) easier to use interface (that is a work in progress) for recording events to the database. Now, you just need to have a "recorder" type that takes `IncompleteEvent`. These objects look like: 

```
interface IncompleteEvent {
  eventTime: Datetime;
  eventType: EventType;
  artifact: IncompleteArtifact;
  contributor: IncompleteContributor;
  amount: number;
  details: object;
};
```

The `IncompleteContributor` and `IncompleteArtifact` allow us to just specify the name/namespace of either and the recorder will handle all of it. Additionally, I had performance issues running imports on events while also handling idempotent writes.  This abstracts all that away. So you just keep calling `record(event: IncompleteEvent)` on the recorder and move on. I'd like to improve this (I took a lot of shortcuts just to get some of the plumbing) but I wanted the bones there for now cause it works well for anything github related. 

This PR _does not_ currently have this all hooked up to github actions. For now I'm just going to make the calls manually into our production database to import the data we need for #2. 