### PR TITLE
Track original author for Issues and PRs

### DIFF
--- a/indexer/src/actions/github/fetch/pull-requests.ts
+++ b/indexer/src/actions/github/fetch/pull-requests.ts
@@ -761,6 +761,8 @@ export class GithubPullRequestFetcher {
         contributor: contributor,
         details: {
           githubId: event.id,
+          // Grab the original author's login if it's there
+          originalAuthorLogin: issue.author?.login || undefined,
         },
       });
     };


### PR DESCRIPTION
Reopen/Close events weren't tracking the original author of the PR/Issue. This adds that to the details. 