### PR TITLE
feat: update dynamic routes for Artifact/Project pages

### DIFF
--- a/frontend/app/project/[...slug]/page.tsx
+++ b/frontend/app/project/[...slug]/page.tsx
@@ -1,10 +1,18 @@
 import { notFound } from "next/navigation";
+import { PlasmicComponent } from "@plasmicapp/loader-nextjs";
+import { PLASMIC } from "../../../plasmic-init";
+import { PlasmicClientRootProvider } from "../../../plasmic-init-client";
 import { cachedGetProjectBySlug } from "../../../lib/db";
 import { logger } from "../../../lib/logger";
 import { catchallPathToString } from "../../../lib/paths";
 
+// Using incremental static regeneration, will invalidate this page
+// after this (no deploy webhooks needed)
+export const revalidate = 3600;
+const PLASMIC_COMPONENT = "ProjectPage";
+
 /**
- * TODO: This SSR route allows us to fetch the project from the database
+ * This SSR route allows us to fetch the project from the database
  * on the first HTTP request, which should be faster than fetching it client-side
  */
 
@@ -12,10 +20,11 @@ type ProjectPageProps = {
   params: {
     slug: string[];
   };
+  searchParams?: Record<string, string | string[]>;
 };
 
 export default async function ProjectPage(props: ProjectPageProps) {
-  const { params } = props;
+  const { params, searchParams } = props;
   const slug = catchallPathToString(params.slug);
   if (!params.slug || !Array.isArray(params.slug) || params.slug.length < 1) {
     logger.warn("Invalid project page path", params);
@@ -29,8 +38,25 @@ export default async function ProjectPage(props: ProjectPageProps) {
     notFound();
   }
 
-  console.log(project);
+  //console.log(project);
+  const plasmicData = await PLASMIC.fetchComponentData(PLASMIC_COMPONENT);
+  const compMeta = plasmicData.entryCompMetas[0];
 
-  // TODO: render the Plasmic page
-  return <div>My Path: {slug}</div>;
+  return (
+    <PlasmicClientRootProvider
+      prefetchedData={plasmicData}
+      pageParams={compMeta.params}
+      pageQuery={searchParams}
+    >
+      <PlasmicComponent
+        component={compMeta.displayName}
+        componentProps={{
+          id: project.id,
+          metadata: project,
+          artifacts: [],
+          collections: [],
+        }}
+      />
+    </PlasmicClientRootProvider>
+  );
 }

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -23,9 +23,15 @@ async function projectMiddleware(request: NextRequest, slug: string) {
 
   // Get the project
   const project = projects[0];
+  const projectStr = JSON.stringify(project);
+  // Pass the metadata into the querystring
+  const encodedProject = encodeURIComponent(projectStr);
   //console.log(project);
   return NextResponse.rewrite(
-    new URL(`/projectById/${project.id}`, request.url),
+    new URL(
+      `/projectById/${project.id}?metadata=${encodedProject}`,
+      request.url,
+    ),
   );
 }
 
@@ -44,7 +50,6 @@ async function artifactMiddleware(
   // Get artifact metadata from the database
   const artifacts = await supabaseQuery({
     tableName: "Artifact",
-    columns: "id,namespace,name",
     filters: [
       ["namespace", "eq", namespace],
       ["name", "eq", name],
@@ -55,11 +60,17 @@ async function artifactMiddleware(
     return NextResponse.next();
   }
 
-  // Get the project
+  // Get the artifact
   const artifact = artifacts[0];
+  const artifactStr = JSON.stringify(artifact);
+  // Pass the metadata into the querystring
+  const encodedArtifact = encodeURIComponent(artifactStr);
   //console.log(artifact);
   return NextResponse.rewrite(
-    new URL(`/artifactById/${artifact.id}`, request.url),
+    new URL(
+      `/artifactById/${artifact.id}?metadata=${encodedArtifact}`,
+      request.url,
+    ),
   );
 }
 
@@ -86,6 +97,8 @@ export async function middleware(request: NextRequest) {
   return NextResponse.next();
 }
 
+// NOTE: disabling for now, using dynamic routing instead
 export const config = {
-  matcher: ["/artifact/:path+", "/project/:path+"],
+  //matcher: ["/artifact/:path+", "/project/:path+"],
+  matcher: [],
 };


### PR DESCRIPTION
* Abstract out ArtifactPage and ProjectPage into re-usable components
* In Plasmic, the pages now wire the params/queries into the component props
* In the dynamic routes, plumb the id/metadata and render the Plasmic component directly